### PR TITLE
Fix order test 

### DIFF
--- a/api/test/order_test.go
+++ b/api/test/order_test.go
@@ -143,7 +143,8 @@ func (ot *orderTest) testStripe(t *testing.T) {
 	// Set the same checkout id previously obtained.
 	obj := map[string]any{
 		// Mocked stripe returns the id in the URL.
-		"id": path.Base(u.Path),
+		"id":   path.Base(u.Path),
+		"mode": stripe.CheckoutSessionModePayment,
 	}
 
 	raw, err := json.Marshal(obj)


### PR DESCRIPTION
## Motivation
Commit c554a1bbc9f55ae7cecded4bf83fc41899f6e78c broke tests. The session mode must be specified in tests.