### PR TITLE
Use no content status when needed

### DIFF
--- a/core/auth/handler.go
+++ b/core/auth/handler.go
@@ -54,7 +54,7 @@ func HandleLogin(db *sqlx.DB, session *scs.SessionManager) web.Handler {
 			return err
 		}
 
-		return web.Respond(ctx, w, nil, http.StatusOK)
+		return web.Respond(ctx, w, nil, http.StatusNoContent)
 	}
 }
 
@@ -161,7 +161,7 @@ func HandleOauthCallback(db *sqlx.DB, session *scs.SessionManager, provs map[str
 			return err
 		}
 
-		return web.Respond(ctx, w, nil, http.StatusOK)
+		return web.Respond(ctx, w, nil, http.StatusNoContent)
 	}
 }
 

--- a/core/order/handler.go
+++ b/core/order/handler.go
@@ -213,7 +213,7 @@ func HandlePaypalCapture(db *sqlx.DB, pp *paypal.Client) web.Handler {
 			return fmt.Errorf("the order was payed but its fulfillment failed: %w", err)
 		}
 
-		return web.Respond(ctx, w, nil, http.StatusOK)
+		return web.Respond(ctx, w, nil, http.StatusNoContent)
 	}
 }
 
@@ -294,7 +294,7 @@ func HandleStripeCapture(db *sqlx.DB, cfg config.Stripe) web.Handler {
 
 		// Filter all the events but the checkout completion one.
 		if event.Type != "checkout.session.completed" {
-			return web.Respond(ctx, w, nil, http.StatusOK)
+			return web.Respond(ctx, w, nil, http.StatusNoContent)
 		}
 
 		var session stripe.CheckoutSession
@@ -305,13 +305,13 @@ func HandleStripeCapture(db *sqlx.DB, cfg config.Stripe) web.Handler {
 
 		// Filter out checkouts that are not for one-time payments.
 		if session.Mode != stripe.CheckoutSessionModePayment {
-			return web.Respond(ctx, w, nil, http.StatusOK)
+			return web.Respond(ctx, w, nil, http.StatusNoContent)
 		}
 
 		if err := fulfill(ctx, db, session.ID); err != nil {
 			return fmt.Errorf("the order was payed but its fulfillment failed: %w", err)
 		}
 
-		return web.Respond(ctx, w, nil, http.StatusOK)
+		return web.Respond(ctx, w, nil, http.StatusNoContent)
 	}
 }


### PR DESCRIPTION
When the response body should be empty, set the status code to `http.StatusNoContent`.
With that status code `web.Respond` will not write anything in the body.