### PR TITLE
Use callback to avoid useless re-renders

### DIFF
--- a/frontend/services/fetch.tsx
+++ b/frontend/services/fetch.tsx
@@ -1,4 +1,5 @@
 import { useSession } from '@/session/context'
+import { useCallback } from 'react'
 
 // useFetch returns a wrapped fetch function that:
 // - adds the 'credentials' header, to allow sending the session cookie to the backend.
@@ -6,18 +7,21 @@ import { useSession } from '@/session/context'
 export function useFetch() {
     const { updateSession } = useSession()
 
-    async function customFetch(url: RequestInfo, options: RequestInit = {}): Promise<Response> {
-        if (options.method !== 'OPTIONS') {
-            options.credentials = 'include'
-        }
+    const customFetch = useCallback(
+        async (url: RequestInfo, options: RequestInit = {}): Promise<Response> => {
+            if (options.method !== 'OPTIONS') {
+                options.credentials = 'include'
+            }
 
-        const response = await fetch(url, options)
-        if (response.status === 401) {
-            updateSession()
-        }
+            const response = await fetch(url, options)
+            if (response.status === 401) {
+                updateSession()
+            }
 
-        return response
-    }
+            return response
+        },
+        [updateSession]
+    )
 
     return customFetch
 }

--- a/frontend/session/context.tsx
+++ b/frontend/session/context.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react'
 import { useEffect } from 'react'
 import { createContext } from 'react'
 import { useContext } from 'react'
+import { useCallback } from 'react'
 
 type Session = {
     isLoggedIn: boolean
@@ -24,21 +25,19 @@ export function SessionProvider(props: { children: ReactNode }) {
     const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false)
     const [isLoading, setIsLoading] = useState<boolean>(true)
 
-    function sync() {
-        const user = async () => {
-            const response = await fetch('http://mylocal.com:8000/users/current', { credentials: 'include' })
-            setIsLoggedIn(response.ok)
+    const sync = useCallback(async () => {
+        try {
+            const resp = await fetch('http://mylocal.com:8000/users/current', { credentials: 'include' })
+            setIsLoggedIn(resp.ok)
+            setIsLoading(false)
+        } catch {
             setIsLoading(false)
         }
-
-        user().catch(() => {
-            setIsLoading(false)
-        })
-    }
+    }, [])
 
     useEffect(() => {
         sync()
-    }, [])
+    }, [sync])
 
     const session: Session = {
         isLoggedIn: isLoggedIn,


### PR DESCRIPTION
By defining `customFetch` and `updateSession` as callbacks we avoid useless re-renders when the custom fetcher is used in a `useEffect`.
Example:
```javascript
  const fetch = useFetch()

  useEffect(() => {
      fetch('http://mylocal.com:8000/users/current')
  }, [fetch])
```
Without using callbacks, this `useEffect` will be executed at every re-render.
With callbacks, it'd be called only once.